### PR TITLE
Admin Router: Finalize tests for Admin Router (part 1)

### DIFF
--- a/packages/adminrouter/extra/src/test-harness/modules/runner/open.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/runner/open.py
@@ -31,6 +31,6 @@ class Nginx(NginxBase):
         """
         NginxBase.__init__(self, **base_kwargs)
 
-        self._set_ar_env_from_val("OUATH_CLIENT_ID", ouath_client_id)
-        self._set_ar_env_from_val("OUATH_AUTH_REDIRECTOR", ouath_auth_redirector)
+        self._set_ar_env_from_val("OAUTH_CLIENT_ID", ouath_client_id)
+        self._set_ar_env_from_val("OAUTH_AUTH_REDIRECTOR", ouath_auth_redirector)
         self._set_ar_env_from_val('SECRET_KEY_FILE_PATH', secret_key_file_path)

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
@@ -1,7 +1,14 @@
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
+import pytest
+import requests
+
 from generic_test_code.common import assert_endpoint_response
 from util import SearchCriteria
+from generic_test_code.common import (
+    overriden_file_content,
+)
+from util import GuardedSubprocess
 
 EXHIBITOR_PATH = "/exhibitor/foo/bar"
 
@@ -9,7 +16,7 @@ EXHIBITOR_PATH = "/exhibitor/foo/bar"
 class TestAuthzIAMBackendQuery:
     def test_if_iam_broken_resp_code_is_handled(
             self,
-            master_ar_process,
+            master_ar_process_perclass,
             valid_user_header,
             mocker,
             ):
@@ -25,7 +32,7 @@ class TestAuthzIAMBackendQuery:
                 SearchCriteria(1, True),
             }
         assert_endpoint_response(
-            master_ar_process,
+            master_ar_process_perclass,
             EXHIBITOR_PATH,
             500,
             assert_stderr=log_messages,
@@ -36,7 +43,7 @@ class TestAuthzIAMBackendQuery:
 class TestAuthnJWTValidatorOpen:
     def test_forged_auth_token(
             self,
-            master_ar_process,
+            master_ar_process_perclass,
             forged_user_header,
             ):
         # Different validators emit different log messages, so we create two
@@ -48,9 +55,44 @@ class TestAuthnJWTValidatorOpen:
             }
 
         assert_endpoint_response(
-            master_ar_process,
+            master_ar_process_perclass,
             EXHIBITOR_PATH,
             401,
             assert_stderr=log_messages,
             headers=forged_user_header,
             )
+
+
+class TestOauthLoginIntegration:
+    @pytest.mark.parametrize(
+        "oa_redir,oa_client_id,oa_cluster_id",
+        (["https://auth.dcos.io",
+          "GiVuhyheiccetcyudJooshac492341sd",
+          "fd615e91-2316-43e2-9f64-390c9256203f",
+          ],
+         ["https://test.abc.ef",
+          "dsaftq13435gssgfw342t2gwr4326uuw",
+          "bcde3e6d-a6dc-4269-abb7-252910e942f7",
+          ],
+         )
+        )
+    def test_if_login_url_works(
+            self,
+            nginx_class,
+            oa_redir,
+            oa_client_id,
+            oa_cluster_id,
+            ):
+        ar = nginx_class(
+            ouath_client_id=oa_client_id,
+            ouath_auth_redirector=oa_redir)
+        url = ar.make_url_from_path('/login?a=1&b=2')
+        expected_path = "{}/login?client={}&cluster_id={}&a=1&b=2".format(
+            oa_redir, oa_client_id, oa_cluster_id)
+
+        with overriden_file_content('/var/lib/dcos/cluster-id', oa_cluster_id):
+            with GuardedSubprocess(ar):
+                r = requests.get(url, allow_redirects=False)
+
+        assert r.status_code == 302
+        assert r.headers['Location'] == expected_path

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -1,4 +1,5 @@
 endpoint_tests:
+######### /system/health/
   - tests:
       is_upstream_correct:
         enabled: true
@@ -15,7 +16,7 @@ endpoint_tests:
         upstream: http:///run/dcos/3dt.sock
     type:
       - agent
-####### /acs/api/v1/auth/
+######### /acs/api/v1/auth/
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -35,7 +36,7 @@ endpoint_tests:
             sent: /acs/api/v1/reflect/me
     type:
       - master
-###### /dcos-metadata/ui-config.json
+######### /dcos-metadata/ui-config.json
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -55,34 +56,3 @@ endpoint_tests:
             sent: /dcos-metadata/ui-config.json
     type:
       - master
-###### /marathon
-  - tests:
-      are_upstream_req_headers_ok:
-        enabled: true
-        jwt_should_be_forwarded: true
-        test_paths:
-          - /marathon
-          - /marathon/
-          - /marathon/v2/reflect/me
-      is_upstream_correct:
-        enabled: true
-        test_paths:
-          - /marathon
-          - /marathon/
-          - /marathon/v2/reflect/me
-        upstream: http://127.0.0.1:8080
-      is_upstream_req_ok:
-        enabled: true
-        expected_http_ver: HTTP/1.1
-        test_paths:
-          - expected: /v2/reflect/me
-            sent: /marathon/v2/reflect/me
-          - expected: /
-            sent: /marathon
-          - expected: /
-            sent: /marathon/
-    type:
-      - master
-
-location_header_rewrite_tests: []
-redirect_tests: []

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -11,17 +11,6 @@ from util import GuardedSubprocess, SearchCriteria, auth_type_str, jwt_type_str
 
 EXHIBITOR_PATH = "/exhibitor/foo/bar"
 
-unauthed_endpoints = [
-    "/exhibitor/exhibitor/v1/cluster/status",
-]
-
-
-class TestAuthEnforcement:
-    @pytest.mark.parametrize("path", unauthed_endpoints)
-    def test_if_unauthn_user_is_granted_access(
-            self, master_ar_process_perclass, path):
-        assert_endpoint_response(master_ar_process_perclass, path, 200)
-
 
 class TestAuthnJWTValidator:
     """Tests scenarios where authentication token isn't provided or is provided

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -25,6 +25,10 @@ endpoint_tests:
         enabled: true
         locations:
           - /exhibitor
+      is_unauthed_access_permitted:
+        enabled: true
+        locations:
+          - /exhibitor/exhibitor/v1/cluster/status
       is_location_header_rewritten:
         enabled: true
         basepath: /exhibitor/v1/ui/index.html

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -21,6 +21,17 @@ endpoint_tests:
             sent: /exhibitor/
           - expected: /exhibitor/v1/cluster/status
             sent: /exhibitor/exhibitor/v1/cluster/status
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /exhibitor
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /exhibitor/v1/ui/index.html
+        endpoint_id: http://127.0.0.1:8181
+        redirect_testscases:
+          - location_expected: http://127.0.0.1/exhibitor/exhibitor/v1/ui/index.html
+            location_set: http://127.0.0.1/exhibitor/v1/ui/index.html
     type:
       - master
 
@@ -36,6 +47,10 @@ endpoint_tests:
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
         upstream: http://127.0.0.1:16000
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /service/scheduler-alwaysthere
       is_upstream_req_ok:
         enabled: true
         expected_http_ver: HTTP/1.1
@@ -47,8 +62,6 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_upstream_req_headers_ok:
-        enabled: false
       is_upstream_correct:
         enabled: true
         test_paths:
@@ -67,8 +80,6 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_upstream_req_headers_ok:
-        enabled: false
       is_upstream_correct:
         enabled: true
         test_paths:
@@ -87,8 +98,6 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_upstream_req_headers_ok:
-        enabled: false
       is_upstream_correct:
         enabled: true
         test_paths:
@@ -107,8 +116,6 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_upstream_req_headers_ok:
-        enabled: false
       is_upstream_correct:
         enabled: true
         test_paths:
@@ -127,8 +134,6 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_upstream_req_headers_ok:
-        enabled: false
       is_upstream_correct:
         enabled: true
         test_paths:
@@ -144,6 +149,48 @@ endpoint_tests:
             sent: /service/nest2/nest1/scheduler-onlymesosdns/
           - expected: /
             sent: /service/nest2/nest1/scheduler-onlymesosdns
+    type:
+      - master
+  - tests:
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /service/scheduler-alwaysthere/foo/bar
+        endpoint_id: http://127.0.0.1:16000
+        redirect_testscases:
+          - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
+          - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/foo/bar
+          - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
+            location_set: /foo/bar
+    type:
+      - master
+  - tests:
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /service/nest1/scheduler-alwaysthere/foo/bar
+        endpoint_id: http://127.0.0.1:17000
+        redirect_testscases:
+          - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
+          - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/foo/bar
+          - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
+            location_set: /foo/bar
+    type:
+      - master
+  - tests:
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /service/nest2/nest1/scheduler-alwaysthere/foo/bar
+        endpoint_id: http://127.0.0.1:18000
+        redirect_testscases:
+          - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
+          - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
+            location_set: http://127.0.0.1/foo/bar
+          - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
+            location_set: /foo/bar
     type:
       - master
 
@@ -182,8 +229,6 @@ endpoint_tests:
         test_paths:
           - /system/health/v1/foo/bar
       # Check Open/EE config for this test:
-      is_upstream_correct:
-        enabled: false
       is_upstream_req_ok:
         enabled: true
         expected_http_ver: HTTP/1.0
@@ -198,7 +243,8 @@ endpoint_tests:
       - master
       - agent
 
-######### /system/v1/agent/ endpoint, Agent A
+######### /system/v1/agent/ endpoint
+# Agent A
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -234,8 +280,7 @@ endpoint_tests:
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0
     type:
       - master
-
-######### /system/v1/agent/ endpoint, Agent B
+# Agent B
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -309,7 +354,7 @@ endpoint_tests:
     type:
       - master
 
-####### /system/v1/logs endpoint
+######### /system/v1/logs endpoint
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -330,11 +375,15 @@ endpoint_tests:
             sent: /system/v1/logs/v1/foo/bar
           - expected: /
             sent: /system/v1/logs/v1/
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /system/v1/logs/v1
     type:
       - master
       - agent
 
-####### /cosmos/service
+######### /cosmos/service
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -358,7 +407,7 @@ endpoint_tests:
     type:
       - master
 
-####### /capabilities
+######### /capabilities
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -379,7 +428,7 @@ endpoint_tests:
     type:
       - master
 
-####### /acs/api/v1/
+######### /acs/api/v1/
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -400,7 +449,7 @@ endpoint_tests:
     type:
       - master
 
-####### /package
+######### /package
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -423,7 +472,7 @@ endpoint_tests:
     type:
       - master
 
-####### /navstar/lashup/key
+######### /navstar/lashup/key
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -444,7 +493,7 @@ endpoint_tests:
     type:
       - master
 
-####### /dcos-history-service/foo/bar
+######### /dcos-history-service/foo/bar
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -465,7 +514,7 @@ endpoint_tests:
     type:
       - master
 
-####### /mesos_dns
+######### /mesos_dns
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -483,10 +532,14 @@ endpoint_tests:
         test_paths:
           - expected: /v1/reflect/me
             sent: /mesos_dns/v1/reflect/me
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /mesos_dns
     type:
       - master
 
-####### /mesos
+######### /mesos
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -504,10 +557,14 @@ endpoint_tests:
         test_paths:
           - expected: /reflect/me
             sent: /mesos/reflect/me
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /mesos
     type:
       - master
 
-####### /pkgpanda
+######### /pkgpanda
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -528,8 +585,28 @@ endpoint_tests:
     type:
       - master
       - agent
+  - tests:
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /pkgpanda/foo/bar
+        endpoint_id: http:///run/dcos/pkgpanda-api.sock
+        redirect_testscases:
+          - location_expected: http://127.0.0.1/pkgpanda/foo/bar
+            location_set: http://127.0.0.1/foo/bar
+    type:
+      - master
+  - tests:
+      is_location_header_rewritten:
+        enabled: true
+        basepath: /pkgpanda/foo/bar
+        endpoint_id: http:///run/dcos/pkgpanda-api.sock
+        redirect_testscases:
+          - location_expected: http://127.0.0.1:61001/pkgpanda/foo/bar
+            location_set: http://127.0.0.1:61001/foo/bar
+    type:
+      - agent
 
-####### /system/v1/metrics endpoint
+######### /system/v1/metrics endpoint
   - tests:
       are_upstream_req_headers_ok:
         enabled: true
@@ -563,74 +640,37 @@ endpoint_tests:
           - /system/v1/metrics/foo/bar
           - /system/v1/metrics/
         upstream: http:///run/dcos/dcos-metrics-master.sock
+      is_endpoint_redirecting_properly:
+        enabled: true
+        locations:
+          - /system/v1/metrics
     type:
       - master
-location_header_rewrite_tests:
-  - basepath: /service/scheduler-alwaysthere/foo/bar
-    endpoint_id: http://127.0.0.1:16000
-    redirect_testscases:
-      - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
-      - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/foo/bar
-      - location_expected: http://127.0.0.1/service/scheduler-alwaysthere/foo/bar
-        location_set: /foo/bar
+######### /marathon
+  - tests:
+      are_upstream_req_headers_ok:
+        enabled: true
+        jwt_should_be_forwarded: true
+        test_paths:
+          - /marathon
+          - /marathon/
+          - /marathon/v2/reflect/me
+      is_upstream_correct:
+        enabled: true
+        test_paths:
+          - /marathon
+          - /marathon/
+          - /marathon/v2/reflect/me
+        upstream: http://127.0.0.1:8080
+      is_upstream_req_ok:
+        enabled: true
+        expected_http_ver: HTTP/1.1
+        test_paths:
+          - expected: /v2/reflect/me
+            sent: /marathon/v2/reflect/me
+          - expected: /
+            sent: /marathon
+          - expected: /
+            sent: /marathon/
     type:
       - master
-  - basepath: /service/nest1/scheduler-alwaysthere/foo/bar
-    endpoint_id: http://127.0.0.1:17000
-    redirect_testscases:
-      - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
-      - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/foo/bar
-      - location_expected: http://127.0.0.1/service/nest1/scheduler-alwaysthere/foo/bar
-        location_set: /foo/bar
-    type:
-      - master
-  - basepath: /service/nest2/nest1/scheduler-alwaysthere/foo/bar
-    endpoint_id: http://127.0.0.1:18000
-    redirect_testscases:
-      - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
-      - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
-        location_set: http://127.0.0.1/foo/bar
-      - location_expected: http://127.0.0.1/service/nest2/nest1/scheduler-alwaysthere/foo/bar
-        location_set: /foo/bar
-    type:
-      - master
-  - basepath: /exhibitor/v1/ui/index.html
-    endpoint_id: http://127.0.0.1:8181
-    redirect_testscases:
-      - location_expected: http://127.0.0.1/exhibitor/exhibitor/v1/ui/index.html
-        location_set: http://127.0.0.1/exhibitor/v1/ui/index.html
-    type:
-      - master
-  - basepath: /pkgpanda/foo/bar
-    endpoint_id: http:///run/dcos/pkgpanda-api.sock
-    redirect_testscases:
-      - location_expected: http://127.0.0.1/pkgpanda/foo/bar
-        location_set: http://127.0.0.1/foo/bar
-    type:
-      - master
-  - basepath: /pkgpanda/foo/bar
-    endpoint_id: http:///run/dcos/pkgpanda-api.sock
-    redirect_testscases:
-      - location_expected: http://127.0.0.1:61001/pkgpanda/foo/bar
-        location_set: http://127.0.0.1:61001/foo/bar
-    type:
-      - agent
-redirect_tests:
-  - endpoints:
-      - /service/scheduler-alwaysthere
-      - /exhibitor
-      - /mesos
-      - /system/v1/metrics
-      - /mesos_dns
-    type:
-      - master
-  - endpoints:
-      - /system/v1/logs/v1
-    type:
-      - master
-      - agent


### PR DESCRIPTION
## High Level Description

This PR:
* reworks generic tests in order to simplify configuration
* adds "is unauth(n|z) access possible" generic tests
* adds "/login" endpoint tests


## Related Issues

- https://jira.mesosphere.com/browse/DCOS-15362 Admin Router: Tests of the nginx.(agent|master).conf

## Dependencies
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/986
Base PR: https://github.com/dcos/dcos/pull/1607
AR-NEXT PR: https://github.com/dcos/dcos/pull/1611