### PR TITLE
Admin Router: Finalize tests for Admin Router (part 2)

### DIFF
--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -112,6 +112,8 @@ COPY cluster-id /var/lib/dcos/cluster-id
 COPY detect_ip_public /opt/mesosphere/bin/detect_ip_public
 RUN chmod -v a+x /opt/mesosphere/bin/detect_ip_public
 COPY active.buildinfo.full.json /opt/mesosphere/active.buildinfo.full.json
+COPY plan-ui-testfile.html /opt/mesosphere/active/dcos-ui/usr/
+COPY nested-ui-testfile.html /opt/mesosphere/active/dcos-ui/usr/nest1/
 
 # The contents of adminrouter-listen* files differ from the ones that are
 # shipped with DC/OS - the IP addresses Nginx binds to are limited to only

--- a/packages/adminrouter/docker/nested-ui-testfile.html
+++ b/packages/adminrouter/docker/nested-ui-testfile.html
@@ -1,0 +1,1 @@
+nested-ui-testfile.html

--- a/packages/adminrouter/docker/plan-ui-testfile.html
+++ b/packages/adminrouter/docker/plan-ui-testfile.html
@@ -1,0 +1,1 @@
+plan-ui-testfile.html

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -304,7 +304,23 @@ def assert_endpoint_response(
 
 @contextmanager
 def overriden_file_content(file_path, new_content=None):
-    with open(file_path, 'r+') as fh:
+    """Context manager meant to simplify static files testsing
+
+    While inside the context, file can be modified and/or modified content
+    may be injected by the context manager itself. Right after context is
+    exited, the original file contents are restored.
+
+    Arguments:
+        file_path: path the the file that should be "guarded"
+        new_content: new content for the file. If None - file contents are not
+            changed, "string" objects are translated to binary blob first,
+            assuming utf-8 encoding.
+    """
+
+    if new_content is not None and not isinstance(new_content, bytes):
+        new_content = new_content.encode('utf-8')
+
+    with open(file_path, 'rb+') as fh:
         old_content = fh.read()
         if new_content is not None:
             fh.seek(0)
@@ -313,7 +329,7 @@ def overriden_file_content(file_path, new_content=None):
 
     yield
 
-    with open(file_path, 'w') as fh:
+    with open(file_path, 'wb') as fh:
         fh.write(old_content)
 
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -63,6 +63,38 @@ def generic_no_slash_redirect_test(ar, path):
     assert r.headers['Location'] == url + '/'
 
 
+def generic_response_headers_verify_test(
+        ar, auth_header, path, assert_headers=None, assert_headers_absent=None):
+    """Test if response sent by AR is correct
+
+    Helper function meant to simplify writing multiple tests testing the
+    same thing for different endpoints.
+
+    Arguments:
+        ar: Admin Router object, an instance of runner.(ee|open).Nginx
+        auth_header (dict): headers dict that contains JWT. The auth data it
+            contains is valid and the request should be accepted.
+        path (str): path for which request should be made
+        assert_headers (dict): additional headers to test where key is the
+            asserted header name and value is expected value
+        assert_headers_absent (dict): headers that *MUST NOT* be present in the
+            upstream request
+    """
+    url = ar.make_url_from_path(path)
+    resp = requests.get(url,
+                        allow_redirects=False,
+                        headers=auth_header)
+
+    assert resp.status_code == 200
+
+    if assert_headers is not None:
+        for name, value in assert_headers.items():
+            verify_header(resp.headers.items(), name, value)
+    if assert_headers_absent is not None:
+        for name in assert_headers_absent:
+            header_is_absent(resp.headers.items(), name)
+
+
 def generic_upstream_headers_verify_test(
         ar, auth_header, path, assert_headers=None, assert_headers_absent=None):
     """Test if headers sent upstream are correct

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -14,10 +14,15 @@ from generic_test_code.common import (
     generic_no_slash_redirect_test,
     generic_upstream_headers_verify_test,
     generic_response_headers_verify_test,
-    repo_is_ee,
 )
 
 log = logging.getLogger(__name__)
+
+# Generalised tests were moved to a separate library included by
+# test-harness/tests/(open|ee)/test_generic.py files because they
+# may require fixturesd from test-harness/tests/(open|ee)/conftest.py which
+# in turn is not reachable/included by test-harness/tests/test_generic.py
+# file.
 
 
 def _merge_testconfig(a, b):
@@ -180,19 +185,12 @@ def _verify_are_response_headers_ok(t_config):
         assert p.startswith('/')
 
 
-def _tests_configuration():
-    curdir = os.path.dirname(os.path.abspath(__file__))
-    common_tests_conf_file = os.path.join(curdir, "test_generic.config.yml")
+def _tests_configuration(path):
+    common_tests_conf_file = os.path.join(path, "..", "test_generic.config.yml")
     with open(common_tests_conf_file, 'r') as fh:
         common_tests_conf = yaml.load(fh)
 
-    if repo_is_ee():
-        flavour_dir = 'ee'
-    else:
-        flavour_dir = 'open'
-
-    flavoured_tests_conf_file = os.path.join(
-        curdir, flavour_dir, "test_generic.config.yml")
+    flavoured_tests_conf_file = os.path.join(path, "test_generic.config.yml")
     with open(flavoured_tests_conf_file, 'r') as fh:
         flavoured_tests_conf = yaml.load(fh)
 
@@ -347,8 +345,8 @@ def _testdata_to_redirect_testdata(tests_config, node_type):
     return res
 
 
-def pytest_generate_tests(metafunc):
-    tests_config = _tests_configuration()
+def create_tests(metafunc, path):
+    tests_config = _tests_configuration(path)
     if 'master_ar_process_perclass' in metafunc.fixturenames:
         ar_type = 'master'
     else:
@@ -391,7 +389,7 @@ def pytest_generate_tests(metafunc):
         return
 
 
-class TestMasterGeneric:
+class GenericTestMasterClass:
     def test_if_request_is_sent_to_correct_upstream(
             self,
             master_ar_process_perclass,
@@ -506,7 +504,7 @@ class TestMasterGeneric:
             )
 
 
-class TestAgentGeneric:
+class GenericTestAgentClass:
     def test_if_request_is_sent_to_correct_upstream(
             self,
             agent_ar_process_perclass,

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 # Generalised tests were moved to a separate library included by
 # test-harness/tests/(open|ee)/test_generic.py files because they
-# may require fixturesd from test-harness/tests/(open|ee)/conftest.py which
+# may require fixtures from test-harness/tests/(open|ee)/conftest.py which
 # in turn is not reachable/included by test-harness/tests/test_generic.py
 # file.
 
@@ -154,7 +154,7 @@ def _verify_is_upstream_req_ok_test_conf(t_config):
         return
 
     assert 'expected_http_ver' in t_config
-    assert t_config['expected_http_ver'] in ['HTTP/1.0', 'HTTP/1.1']
+    assert t_config['expected_http_ver'] in ['HTTP/1.0', 'HTTP/1.1', 'websockets']
 
     assert 'test_paths' in t_config
     for p in t_config['test_paths']:

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
@@ -33,10 +33,10 @@ class IamHTTPRequestHandler(RecordingHTTPRequestHandler):
         if match:
             return self.__users_permissions_request_handler(match.group(1))
 
-        if base_path in [
-                '/acs/api/v1/reflect/me',
-                '/dcos-metadata/ui-config.json',
-                '/acs/api/v1/auth/reflect/me']:
+        reflecting_paths = [
+            '/acs/api/v1/reflect/me',
+            '/dcos-metadata/ui-config.json']
+        if base_path in reflecting_paths or base_path.startswith('/acs/api/v1/auth/'):
             # A test URI that is used by tests. In some cases it is impossible
             # to reuse /acs/api/v1/users/ path.
             return self._reflect_request(base_path, url_args, body_args)

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -1,5 +1,7 @@
 endpoint_tests:
 ######### /system/health/
+# there are differences in how upstreams are configured between EE and Open,
+# hence the tests separation
   - tests:
       is_upstream_correct:
         enabled: true
@@ -18,6 +20,10 @@ endpoint_tests:
       - agent
 ######### /acs/api/v1/auth/
   - tests:
+      is_unauthed_access_permitted:
+        enabled: true
+        locations:
+          - /acs/api/v1/auth/reflect/me
       are_upstream_req_headers_ok:
         enabled: true
         jwt_should_be_forwarded: skip
@@ -32,8 +38,8 @@ endpoint_tests:
         enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
-          - expected: /acs/api/v1/reflect/me
-            sent: /acs/api/v1/reflect/me
+          - expected: /acs/api/v1/auth/reflect/me
+            sent: /acs/api/v1/auth/reflect/me
     type:
       - master
 ######### /dcos-metadata/ui-config.json

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.py
@@ -1,0 +1,25 @@
+# Copyright (C) Mesosphere, Inc. See LICENSE file for details.
+
+import os
+
+from generic_test_code.generalised_tests import (
+    create_tests,
+    GenericTestMasterClass,
+    GenericTestAgentClass,
+)
+
+# Please check comment at the top of
+# test-harness/modules/generic_test_code/generalised_tests.py
+# for explanation why this test code is structured this way.
+
+
+def pytest_generate_tests(metafunc):
+    create_tests(metafunc, os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestMasterGeneric(GenericTestMasterClass):
+    pass
+
+
+class TestAgentGeneric(GenericTestAgentClass):
+    pass

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -434,6 +434,11 @@ endpoint_tests:
 
 ######### /acs/api/v1/
   - tests:
+      are_response_headers_ok:
+        enabled: true
+        nocaching_headers_are_sent: true
+        test_paths:
+          - /acs/api/v1/reflect/me
       are_upstream_req_headers_ok:
         enabled: true
         jwt_should_be_forwarded: true

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -57,7 +57,7 @@ endpoint_tests:
           - /service/scheduler-alwaysthere
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/scheduler-alwaysthere/foo/bar
@@ -73,7 +73,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:17000
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/nest1/scheduler-alwaysthere/foo/bar
@@ -91,7 +91,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:18000
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/nest2/nest1/scheduler-alwaysthere/foo/bar
@@ -109,7 +109,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:18001
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/nest2/nest1/scheduler-onlymarathon/foo/bar
@@ -127,7 +127,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:18002
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/nest2/nest1/scheduler-onlymesos/foo/bar
@@ -145,7 +145,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:18003
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
             sent: /service/nest2/nest1/scheduler-onlymesosdns/foo/bar
@@ -673,7 +673,7 @@ endpoint_tests:
         upstream: http://127.0.0.1:8080
       is_upstream_req_ok:
         enabled: true
-        expected_http_ver: HTTP/1.1
+        expected_http_ver: websockets
         test_paths:
           - expected: /v2/reflect/me
             sent: /marathon/v2/reflect/me

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -205,12 +205,16 @@ endpoint_tests:
         jwt_should_be_forwarded: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
+          - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
       is_upstream_correct:
         enabled: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1
+          - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/
-          - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
+          - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
+          - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/
+          - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
         upstream: http://127.0.0.2:15001
       is_upstream_req_ok:
         enabled: true
@@ -222,6 +226,12 @@ endpoint_tests:
             sent: /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/
           - expected: /foo/bar
             sent: /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
+          - expected: /
+            sent: /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1
+          - expected: /
+            sent: /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/
+          - expected: /foo/bar
+            sent: /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
     type:
       - master
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.py
@@ -438,6 +438,10 @@ class TestMasterGeneric:
             self, master_ar_process_perclass, redirect_path):
         generic_no_slash_redirect_test(master_ar_process_perclass, redirect_path)
 
+    def test_if_unauthn_user_is_granted_access(
+            self, master_ar_process_perclass, unauthed_path):
+        assert_endpoint_response(master_ar_process_perclass, unauthed_path, 200)
+
 
 class TestAgentGeneric:
     def test_if_request_is_sent_to_correct_upstream(
@@ -527,5 +531,5 @@ class TestAgentGeneric:
         generic_no_slash_redirect_test(agent_ar_process_perclass, redirect_path)
 
     def test_if_unauthn_user_is_granted_access(
-            self, master_ar_process_perclass, unauthed_path):
-        assert_endpoint_response(master_ar_process_perclass, unauthed_path, 200)
+            self, agent_ar_process_perclass, unauthed_path):
+        assert_endpoint_response(agent_ar_process_perclass, unauthed_path, 200)

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -36,7 +36,8 @@ class TestLogsEndpoint:
                                              )
 
 
-class TestService:
+class TestServiceEndpoint:
+    # Majority of /service endpoint tests are done with generic tests framework
     def test_if_accept_encoding_header_is_removed_from_upstream_request(
             self, master_ar_process_perclass, mocker, valid_user_header):
         headers = copy.deepcopy(valid_user_header)
@@ -45,6 +46,20 @@ class TestService:
         generic_upstream_headers_verify_test(master_ar_process_perclass,
                                              headers,
                                              '/service/scheduler-alwaysthere/foo/bar/',
+                                             assert_headers_absent=["Accept-Encoding"],
+                                             )
+
+
+class TestAgentEndpoint:
+    # Tests for /agent endpoint routing are done in test_cache.py
+    def test_if_accept_encoding_header_is_removed_from_upstream_request(
+            self, master_ar_process_perclass, mocker, valid_user_header):
+        headers = copy.deepcopy(valid_user_header)
+        headers['Accept-Encoding'] = 'gzip'
+
+        generic_upstream_headers_verify_test(master_ar_process_perclass,
+                                             headers,
+                                             '/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/',
                                              assert_headers_absent=["Accept-Encoding"],
                                              )
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -37,18 +37,6 @@ class TestLogsEndpoint:
 
 
 class TestService:
-    def test_if_websockets_conn_upgrade_is_supported(
-            self, master_ar_process_perclass, mocker, valid_user_header):
-        headers = copy.deepcopy(valid_user_header)
-        headers['Upgrade'] = 'WebSocket'
-        headers['Connection'] = 'upgrade'
-
-        generic_upstream_headers_verify_test(master_ar_process_perclass,
-                                             headers,
-                                             '/service/scheduler-alwaysthere/foo/bar/',
-                                             assert_headers=headers,
-                                             )
-
     def test_if_accept_encoding_header_is_removed_from_upstream_request(
             self, master_ar_process_perclass, mocker, valid_user_header):
         headers = copy.deepcopy(valid_user_header)

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -277,3 +277,25 @@ class TestMetadata:
         assert resp.status_code == 200
         resp_data = resp.json()
         assert resp_data['PUBLIC_IPV4'] == "127.0.0.1"
+
+
+class TestUiRoot:
+    @pytest.mark.parametrize("uniq_content", ["(｡◕‿‿◕｡)", "plain text 1234"])
+    @pytest.mark.parametrize("path", ["plan-ui-testfile.html",
+                                      "nest1/nested-ui-testfile.html"])
+    def test_if_ui_files_are_handled(
+        self, master_ar_process_perclass, valid_user_header, uniq_content, path):
+
+        url = master_ar_process_perclass.make_url_from_path('/{}'.format(path))
+
+        with overriden_file_content(
+                '/opt/mesosphere/active/dcos-ui/usr/{}'.format(path),
+                uniq_content):
+            resp = requests.get(
+                url,
+                allow_redirects=False,
+                headers=valid_user_header)
+
+        assert resp.status_code == 200
+        resp.encoding = 'utf-8'
+        assert resp.text == uniq_content

--- a/packages/adminrouter/extra/src/test-harness/tests/test_service.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_service.py
@@ -256,7 +256,7 @@ class TestServiceStateful:
             valid_user_header,
             '/service/scheduler-alwaysthere/foo/bar/',
             '/foo/bar/',
-            http_ver='HTTP/1.1'
+            http_ver='websockets'
             )
 
         # Test webui_url entry with trailing slash:
@@ -278,7 +278,7 @@ class TestServiceStateful:
             valid_user_header,
             '/service/scheduler-alwaysthere/foo/bar/',
             '/foo/bar/',
-            http_ver='HTTP/1.1'
+            http_ver='websockets'
             )
 
     def test_if_broken_json_from_mesos_dns_is_handled(


### PR DESCRIPTION
## High Level Description

This PR:
* add missing tests for all AR endpoints cntd.
* make `generic_correct_upstream_request_test` more strict
* refactors generalised tests into a library so that we can walk around the problem of fixtures not being included in directories above `ee/` and `open/` 
* adds "response is correct" generic tests (e.g. whether caching headers are properly set)
* adds "is unauth(n|z) access possible" generic tests

## Related Issues
- https://jira.mesosphere.com/browse/DCOS-15362 Admin Router: Tests of the nginx.(agent|master).conf

## Dependencies
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/988
Base PR: https://github.com/dcos/dcos/pull/1607
AR-NEXT PR: dcos#1611