### PR TITLE
Admin Router: rename `make flake8` target to `make lint`

### DIFF
--- a/Jenkinsfile-insecure.groovy
+++ b/Jenkinsfile-insecure.groovy
@@ -8,8 +8,8 @@ dir("packages/adminrouter/extra/src") {
             sh 'make check-api-docs'
         }
 
-        stage('make flake8') {
-            sh 'make flake8'
+        stage('make lint') {
+            sh 'make lint'
         }
 
         stage('make test') {

--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -115,8 +115,8 @@ check-api-docs: api-docs
 	@git ls-files --exclude-standard --others || (echo 'Found untracked and unignored changes. Please run `make api-docs` and commit the result.' >&2 && exit 1)
 	@echo 'No changes found -- Admin Router API docs are up to date.' >&2
 
-.PHONY: flake8
-flake8: clean-devkit-container devkit
+.PHONY: lint
+lint: clean-devkit-container devkit
 	#FIXME - split it into two targets
 	docker run \
 		$(DEVKIT_DOCKER_OPTS) \

--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -660,8 +660,8 @@ It exposes a couple of targets:
    equal to or above 10.
 * `make shell` - launch an interactive shell within the devkit container. Should
   be used when fine grained control of the tests is necessary or during debugging.
-* `make flake8` - launch flake8 which will check all the tests and test-harness
-  files by default.
+* `make lint` - launch linters which will check the tests code and test-harness
+  code by default.
 
 ### Docker container
 As mentioned earlier, all the commands are executed inside the `adminrouter-devkit`


### PR DESCRIPTION
# High Level Description

Rename `make flake8` to `make lint` in order to conform to new guidelines:

https://wiki.mesosphere.com/pages/diffpagesbyversion.action?pageId=82903151&selectedPageVersions=17&selectedPageVersions=16

# Related PRs
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1260
AR-NEXT: https://github.com/dcos/dcos/pull/1802

