### PR TITLE
Admin Router: Remove unused "enabled" flag from generic tests

### DIFF
--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -61,15 +61,7 @@ def _verify_endpoint_tests_conf(endpoint_tests):
         _check_all_keys_are_present_in_dict(t, ['tests', 'type'])
         _verify_type_specification(t['type'])
 
-        at_least_one_test_enabled = False
-        assert 0 < len(t['tests'].keys()) < 7
-        for k in t['tests']:
-            assert 'enabled' in t['tests'][k]
-            assert t['tests'][k]['enabled'] in [True, False]
-            at_least_one_test_enabled = at_least_one_test_enabled or \
-                t['tests'][k]['enabled']
-
-        assert at_least_one_test_enabled
+        assert 0 < len(t['tests'].keys()) < 8
 
         if 'is_endpoint_redirecting_properly' in t['tests']:
             _verify_is_endpoint_redirecting_properly(
@@ -95,12 +87,9 @@ def _verify_endpoint_tests_conf(endpoint_tests):
 
 
 def _verify_is_location_header_rewritten(t_config):
-    if not t_config['enabled']:
-        return
-
     _check_all_keys_are_present_in_dict(
         t_config,
-        ['basepath', 'endpoint_id', 'redirect_testscases', 'enabled'])
+        ['basepath', 'endpoint_id', 'redirect_testscases'])
 
     assert t_config['endpoint_id'].startswith('http')
     assert t_config['basepath'].startswith('/')
@@ -116,9 +105,6 @@ def _verify_is_location_header_rewritten(t_config):
 
 
 def _verify_is_endpoint_redirecting_properly(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'locations' in t_config
 
     assert len(t_config['locations']) > 0
@@ -129,9 +115,6 @@ def _verify_is_endpoint_redirecting_properly(t_config):
 
 
 def _verify_is_unauthed_access_permitted(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'locations' in t_config
 
     assert len(t_config['locations']) > 0
@@ -140,9 +123,6 @@ def _verify_is_unauthed_access_permitted(t_config):
 
 
 def _verify_is_upstream_correct_test_conf(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'upstream' in t_config
     assert t_config['upstream'].startswith('http')
 
@@ -152,9 +132,6 @@ def _verify_is_upstream_correct_test_conf(t_config):
 
 
 def _verify_is_upstream_req_ok_test_conf(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'expected_http_ver' in t_config
     assert t_config['expected_http_ver'] in ['HTTP/1.0', 'HTTP/1.1', 'websockets']
 
@@ -164,9 +141,6 @@ def _verify_is_upstream_req_ok_test_conf(t_config):
 
 
 def _verify_are_upstream_req_headers_ok(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'jwt_should_be_forwarded' in t_config
     assert t_config['jwt_should_be_forwarded'] in [True, False, 'skip']
 
@@ -176,9 +150,6 @@ def _verify_are_upstream_req_headers_ok(t_config):
 
 
 def _verify_are_response_headers_ok(t_config):
-    if not t_config['enabled']:
-        return
-
     assert 'nocaching_headers_are_sent' in t_config
     assert t_config['nocaching_headers_are_sent'] in [True, False, 'skip']
 
@@ -213,8 +184,6 @@ def _testdata_to_is_upstream_correct_testdata(tests_config, node_type):
             continue
 
         h = x['tests']['is_upstream_correct']
-        if h['enabled'] is not True:
-            continue
 
         for p in h['test_paths']:
             e = (p, h['upstream'])
@@ -234,8 +203,6 @@ def _testdata_to_is_upstream_req_ok_testdata(tests_config, node_type):
             continue
 
         h = x['tests']['is_upstream_req_ok']
-        if h['enabled'] is not True:
-            continue
 
         for p in h['test_paths']:
             e = (p['sent'], p['expected'], h['expected_http_ver'])
@@ -255,8 +222,6 @@ def _testdata_to_are_upstream_req_headers_ok_testdata(tests_config, node_type):
             continue
 
         h = x['tests']['are_upstream_req_headers_ok']
-        if h['enabled'] is not True:
-            continue
 
         for p in h['test_paths']:
             e = (p, h['jwt_should_be_forwarded'])
@@ -276,8 +241,6 @@ def _testdata_to_location_header_rewrite_testdata(tests_config, node_type):
             continue
 
         h = x['tests']['is_location_header_rewritten']
-        if h['enabled'] is not True:
-            continue
 
         for l in h['redirect_testscases']:
             res.append(
@@ -301,8 +264,6 @@ def _testdata_to_is_unauthed_access_permitted(tests_config, node_type):
             continue
 
         h = x['tests']['is_unauthed_access_permitted']
-        if h['enabled'] is not True:
-            continue
 
         res.extend(h['locations'])
 
@@ -320,8 +281,6 @@ def _testdata_to_are_response_headers_ok(tests_config, node_type):
             continue
 
         h = x['tests']['are_response_headers_ok']
-        if h['enabled'] is not True:
-            continue
 
         res.extend([(x, h['nocaching_headers_are_sent']) for x in h['test_paths']])
 
@@ -339,8 +298,6 @@ def _testdata_to_redirect_testdata(tests_config, node_type):
             continue
 
         h = x['tests']['is_endpoint_redirecting_properly']
-        if h['enabled'] is not True:
-            continue
 
         for l in h['locations']:
             res.append((l['path'], l['code']))

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -4,7 +4,6 @@ endpoint_tests:
 # hence the tests separation
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/health/v1/foo/bar
         upstream: http://127.0.0.1:1050
@@ -12,12 +11,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/health/v1/foo/bar
         upstream: http:///run/dcos/dcos-diagnostics.sock
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /system/health/v1/foo/bar
     type:
@@ -25,21 +22,17 @@ endpoint_tests:
 ######### /acs/api/v1/auth/
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /acs/api/v1/auth/reflect/me
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /acs/api/v1/auth/reflect/me
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /acs/api/v1/auth/reflect/me
         upstream: http://127.0.0.1:8101
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /acs/api/v1/auth/reflect/me
@@ -49,21 +42,17 @@ endpoint_tests:
 ######### /dcos-metadata/ui-config.json
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /dcos-metadata/ui-config.json
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /dcos-metadata/ui-config.json
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /dcos-metadata/ui-config.json
         upstream: http://127.0.0.1:8101
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /dcos-metadata/ui-config.json
@@ -73,7 +62,6 @@ endpoint_tests:
 ######### /pkgpanda/
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /pkgpanda/foo/bar
     type:
@@ -81,7 +69,6 @@ endpoint_tests:
 ######### /system/v1/metrics/
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /system/v1/metrics/foo/bar
     type:
@@ -89,7 +76,6 @@ endpoint_tests:
 ######### /system/v1/logs/
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /system/v1/logs/foo/bar
     type:

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -2,17 +2,14 @@ endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /exhibitor/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /exhibitor/foo/bar
         upstream: http://127.0.0.1:8181
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /foo/bar
@@ -22,16 +19,13 @@ endpoint_tests:
           - expected: /exhibitor/v1/cluster/status
             sent: /exhibitor/exhibitor/v1/cluster/status
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /exhibitor
             code: 301
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /exhibitor/exhibitor/v1/cluster/status
       is_location_header_rewritten:
-        enabled: true
         basepath: /exhibitor/v1/ui/index.html
         endpoint_id: http://127.0.0.1:8181
         redirect_testscases:
@@ -43,22 +37,18 @@ endpoint_tests:
 ######### /service endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
         upstream: http://127.0.0.1:16000
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /service/scheduler-alwaysthere
             code: 301
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -69,12 +59,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/nest1/scheduler-alwaysthere/foo/bar
         upstream: http://127.0.0.1:17000
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -87,12 +75,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/nest2/nest1/scheduler-alwaysthere/foo/bar
         upstream: http://127.0.0.1:18000
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -105,12 +91,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/nest2/nest1/scheduler-onlymarathon/foo/bar
         upstream: http://127.0.0.1:18001
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -123,12 +107,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/nest2/nest1/scheduler-onlymesos/foo/bar
         upstream: http://127.0.0.1:18002
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -141,12 +123,10 @@ endpoint_tests:
       - master
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /service/nest2/nest1/scheduler-onlymesosdns/foo/bar
         upstream: http://127.0.0.1:18003
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /foo/bar
@@ -159,7 +139,6 @@ endpoint_tests:
       - master
   - tests:
       is_location_header_rewritten:
-        enabled: true
         basepath: /service/scheduler-alwaysthere/foo/bar
         endpoint_id: http://127.0.0.1:16000
         redirect_testscases:
@@ -173,7 +152,6 @@ endpoint_tests:
       - master
   - tests:
       is_location_header_rewritten:
-        enabled: true
         basepath: /service/nest1/scheduler-alwaysthere/foo/bar
         endpoint_id: http://127.0.0.1:17000
         redirect_testscases:
@@ -187,7 +165,6 @@ endpoint_tests:
       - master
   - tests:
       is_location_header_rewritten:
-        enabled: true
         basepath: /service/nest2/nest1/scheduler-alwaysthere/foo/bar
         endpoint_id: http://127.0.0.1:18000
         redirect_testscases:
@@ -203,13 +180,11 @@ endpoint_tests:
 ######### /agent endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
           - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/
@@ -219,7 +194,6 @@ endpoint_tests:
           - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
         upstream: http://127.0.0.2:15001
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /
@@ -240,13 +214,11 @@ endpoint_tests:
 ######### /system/health/ endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/health/v1/foo/bar
       # Check Open/EE config for this test:
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /system/health/v1/foo/bar
@@ -263,13 +235,11 @@ endpoint_tests:
 # Agent A
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/foo/bar?key=value&var=num
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/foo/bar?key=value&var=num
@@ -279,7 +249,6 @@ endpoint_tests:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0
         upstream: http://127.0.0.2:61001
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /system/v1/logs/foo/bar?key=value&var=num
@@ -299,13 +268,11 @@ endpoint_tests:
 # Agent B
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0/foo/bar?key=value&var=num
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0/foo/bar?key=value&var=num
@@ -315,7 +282,6 @@ endpoint_tests:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0
         upstream: http://127.0.0.3:61001
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /system/v1/logs/foo/bar?key=value&var=num
@@ -336,13 +302,11 @@ endpoint_tests:
 ######### /system/v1/leader endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
           - /system/v1/leader/marathon/foo/bar?key=value&var=num
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
           - /system/v1/leader/mesos/
@@ -352,7 +316,6 @@ endpoint_tests:
           - /system/v1/leader/marathon
         upstream: http://127.0.0.2:80
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /system/v1/foo/bar?key=value&var=num
@@ -373,18 +336,15 @@ endpoint_tests:
 ######### /system/v1/logs endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/logs/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/logs/foo/bar
           - /system/v1/logs/
         upstream: http:///run/dcos/dcos-log.sock
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /foo/bar
@@ -392,7 +352,6 @@ endpoint_tests:
           - expected: /
             sent: /system/v1/logs/
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /system/v1/logs
             code: 301
@@ -403,18 +362,15 @@ endpoint_tests:
 ######### /cosmos/service
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /cosmos/service/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /cosmos/service/
           - /cosmos/service/foo/bar
         upstream: http://127.0.0.1:7070
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /service/
@@ -427,17 +383,14 @@ endpoint_tests:
 ######### /capabilities
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /capabilities
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /capabilities
         upstream: http://127.0.0.1:7070
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /capabilities
@@ -448,22 +401,18 @@ endpoint_tests:
 ######### /acs/api/v1/
   - tests:
       are_response_headers_ok:
-        enabled: true
         nocaching_headers_are_sent: true
         test_paths:
           - /acs/api/v1/reflect/me
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /acs/api/v1/reflect/me
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /acs/api/v1/reflect/me
         upstream: http://127.0.0.1:8101
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /acs/api/v1/reflect/me
@@ -474,17 +423,14 @@ endpoint_tests:
 ######### /package
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /package/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /package/foo/bar
         upstream: http://127.0.0.1:7070
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /package/
@@ -497,17 +443,14 @@ endpoint_tests:
 ######### /navstar/lashup/key
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /navstar/lashup/key
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /navstar/lashup/key
         upstream: http://127.0.0.1:62080
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /lashup/key
@@ -518,17 +461,14 @@ endpoint_tests:
 ######### /dcos-history-service/foo/bar
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /dcos-history-service/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /dcos-history-service/foo/bar
         upstream: http://127.0.0.1:15055
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /foo/bar
@@ -539,23 +479,19 @@ endpoint_tests:
 ######### /mesos_dns
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: false
         test_paths:
           - /mesos_dns/v1/reflect/me
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /mesos_dns/v1/reflect/me
         upstream: http://127.0.0.1:8123
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /v1/reflect/me
             sent: /mesos_dns/v1/reflect/me
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /mesos_dns
             code: 301
@@ -565,23 +501,19 @@ endpoint_tests:
 ######### /mesos
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /mesos/reflect/me
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /mesos/reflect/me
         upstream: http://127.0.0.2:5050
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /reflect/me
             sent: /mesos/reflect/me
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /mesos
             code: 301
@@ -591,17 +523,14 @@ endpoint_tests:
 ######### /pkgpanda
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /pkgpanda/foo/bar
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /pkgpanda/foo/bar
         upstream: http:///run/dcos/pkgpanda-api.sock
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /foo/bar
@@ -611,7 +540,6 @@ endpoint_tests:
       - agent
   - tests:
       is_location_header_rewritten:
-        enabled: true
         basepath: /pkgpanda/foo/bar
         endpoint_id: http:///run/dcos/pkgpanda-api.sock
         redirect_testscases:
@@ -621,7 +549,6 @@ endpoint_tests:
       - master
   - tests:
       is_location_header_rewritten:
-        enabled: true
         basepath: /pkgpanda/foo/bar
         endpoint_id: http:///run/dcos/pkgpanda-api.sock
         redirect_testscases:
@@ -633,7 +560,6 @@ endpoint_tests:
 ######### /pkgpanda/active.buildinfo.full.json
   - tests:
       are_response_headers_ok:
-        enabled: true
         nocaching_headers_are_sent: true
         test_paths:
           - /pkgpanda/active.buildinfo.full.json
@@ -641,7 +567,6 @@ endpoint_tests:
       - master
   - tests:
       is_unauthed_access_permitted:
-        enabled: true
         locations:
           - /dcos-metadata/dcos-version.json
     type:
@@ -651,12 +576,10 @@ endpoint_tests:
 ######### /system/v1/metrics endpoint
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/metrics/foo/bar
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: HTTP/1.0
         test_paths:
           - expected: /foo/bar
@@ -668,7 +591,6 @@ endpoint_tests:
       - agent
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/metrics/foo/bar
           - /system/v1/metrics/
@@ -677,13 +599,11 @@ endpoint_tests:
       - agent
   - tests:
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /system/v1/metrics/foo/bar
           - /system/v1/metrics/
         upstream: http:///run/dcos/dcos-metrics-master.sock
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /system/v1/metrics
             code: 301
@@ -692,19 +612,16 @@ endpoint_tests:
 ######### /marathon
   - tests:
       are_upstream_req_headers_ok:
-        enabled: true
         jwt_should_be_forwarded: true
         test_paths:
           - /marathon/
           - /marathon/v2/reflect/me
       is_upstream_correct:
-        enabled: true
         test_paths:
           - /marathon/
           - /marathon/v2/reflect/me
         upstream: http://127.0.0.1:8080
       is_upstream_req_ok:
-        enabled: true
         expected_http_ver: websockets
         test_paths:
           - expected: /v2/reflect/me
@@ -712,7 +629,6 @@ endpoint_tests:
           - expected: /
             sent: /marathon/
       is_endpoint_redirecting_properly:
-        enabled: true
         locations:
           - path: /marathon
             code: 307


### PR DESCRIPTION
## High Level Description

* remove the unused "enabled" flag from generic tests
* fixed the generic tests YAML validator error - there are now seven different tests that can be defined in `tests` dictionary of the configuration, so the test for the number of tests should permit that.

## Related PRs:
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1261
AR-NEXT: https://github.com/dcos/dcos/pull/1802