### PR TITLE
Admin Router: Redundant slashes test for `/service` endpoint

### DIFF
--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -74,6 +74,18 @@ endpoint_tests:
     type:
       - master
   - tests:
+      # This test checks whether AR's `/service` endpoint is able to route to
+      # the correct service even though the request url contains duplicate
+      # slashes.  Duplicate slashes is AFAIK not a valid RFC behaviour, but
+      # let's be sure this is handled as well.
+      is_upstream_req_ok:
+        expected_http_ver: websockets
+        test_paths:
+          - expected: /foo/bar
+            sent: /service////nest1////scheduler-alwaysthere///foo/bar
+    type:
+      - master
+  - tests:
       is_upstream_correct:
         test_paths:
           - /service/nest2/nest1/scheduler-alwaysthere/foo/bar


### PR DESCRIPTION
## High Level Description

This PR introduces a test that checks if duplicate slashes are handled by AR.

The question here is whether we want to support `/service` endpoint mapping request for `/service/foo///bar/baz.jpg` to a different task/framework than a request for `/service/foo/bar/baz.jpg`. 

The RFC says https://www.rfc-editor.org/rfc/rfc3986.txt (chapter 3.3):

```
A path consists of a sequence of path segments separated by a slash ("/") character.
```
instead of
```
The path may consist of a sequence of path segments separated by a single slash "/" character.
```

So at least in theory, it is valid to have empty URL segments in the path and they are treated as valid segments which take part in routing decision.  On the other hand, Apache HTTPd and Linux file systems map multiple adjacent segments to the same path (https://webmasters.stackexchange.com/a/8381).

Let's look at this from the perspective of DC/OS:
* what is the current behaviour? 
Application ID consists of Application Groups. I have made a simple experiment - installed a service into Application id `foo/bar///baz/Nginx` and then tried with `foo/bar/baz/Nginx`. The second attempt failed with the message that service with given Application ID already exists. So it seems that Marathon at least internally does not differentiate between these two. AR in this situation was still able to route to correct destination as the request path and Application ID are both normalized (-> redunant slashes are removed) before the routing decision is made. In case of Mesos I think this works a bit more transparently as frameworkID field in `/steate-summary` output is ATM free-form field and and you can have both duplicate slashes in there as well as multiple frameworks registering with the same Application ID.
* what is the "bigger picuture" when it comes to DC/OS and its principles
I am not 100% sure about exact DC/OS terminology but Application Groups are basically namespaces. Having empty Application Group (-> duplicate slashes) means that we have a namespace that is named "" (empty string). At least in bouncer we were forcing groups to be at least few characters long, I am not sure if such a namespace names make sense.

So my conclusion was to follow the "robustness principle": https://en.wikipedia.org/wiki/Robustness_principle#Interpretation
```
RFC 1122 (1989) expanded on Postel's principle by recommending that programmers "assume that the network is filled with malevolent entities that will send in packets designed to have the worst possible effect".[2] Protocols should allow for the addition of new codes for existing fields in future versions of protocols by accepting messages with unknown codes (possibly logging them). Programmers should avoid sending messages with "legal but obscure protocol features" that might expose deficiencies in receivers, and design their code "not just to survive other misbehaving hosts, but also to cooperate to limit the amount of disruption such hosts can cause to the shared communication facility".[3]
```
AR currently normalizes all paths into a common representation before comparing them. This is compatible with the assumption that empty namespace name is an invalid name.

As for the reasoning behind this test in general - I had a discussion with Jose ~2 months ago, he had a problem with a client sending duplicate slashes and thus breaking Cosmos. Writing this test helped me convince him that this is unrelated to Admin Router. I can find this conversation if necessary but it will take time.

## Related issues
https://jira.mesosphere.com/browse/DCOS_OSS-1510 Admin Router: Write tests for AR behaviour wrt. handling duplicate slashes by `/service` endpoint

## Related PRs:
AR-NEXT: https://github.com/dcos/dcos/pull/1802