### PR TITLE
Admin Router: Replace JWT with "DC/OS authentication token"

### DIFF
--- a/packages/adminrouter/extra/src/lib/auth/common.lua
+++ b/packages/adminrouter/extra/src/lib/auth/common.lua
@@ -118,7 +118,7 @@ local function validate_jwt(secret_key)
         return nil, 401
     end
 
-    ngx.log(ngx.NOTICE, "UID from valid JWT: `".. uid .. "`")
+    ngx.log(ngx.NOTICE, "UID from the valid DC/OS authentication token: `".. uid .. "`")
     return uid, nil
 end
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -28,8 +28,8 @@ def ping_mesos_agent(ar,
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is invalid.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is invalid.
         expect_status (int): HTTP status to expect
         endpoint_id (str): if expect_status==200 - id of the endpoint that
             should respoind to the request
@@ -75,8 +75,9 @@ def generic_response_headers_verify_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         assert_headers (dict): additional headers to test where key is the
             asserted header name and value is expected value
@@ -168,8 +169,9 @@ def generic_upstream_headers_verify_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         assert_headers (dict): additional headers to test where key is the
             asserted header name and value is expected value
@@ -205,8 +207,9 @@ def generic_correct_upstream_dest_test(ar, auth_header, path, endpoint_id):
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         endpoint_id (str): id of the endpoint where the upstream request should
             have been sent
@@ -230,8 +233,9 @@ def generic_correct_upstream_request_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         given_path (str): path for which request should be made
         expected_path (str): path that is expected to be sent to upstream
         http_ver (str): http version string that the upstream request should be
@@ -285,7 +289,7 @@ def generic_location_header_during_redirect_is_adjusted_test(
         mocker (Mocker): instance of the Mocker class, used for controlling
             upstream HTTP endpoint/mock
         ar: Admin Router object, an instance of `runner.(ee|open).Nginx`.
-        auth_header (dict): headers dict that contains JWT.
+        auth_header (dict): headers dict that contains DC/OS authentication token.
         endpoint_id (str): id of the endpoint where the upstream request should
             have been sent.
         basepath (str): the URI used by the test harness to issue the request

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -345,15 +345,16 @@ def _universal_test_if_upstream_headers_are_correct(
     # both dcos-* cookies should be removed by AR
     # the dcos-acs-auth-cookie cookie is simply the DC/OS authentication token:
     jar['dcos-acs-auth-cookie'] = valid_user_header['Authorization']
-    # the dcos-acs-info-cookie is base64-encoded data for dc/os UI,
-    # currently set to default user and password
+    # the dcos-acs-info-cookie is a base64-encoded JSON-encoded dictionary
+    # which contains `uid`, `descrption` and `is_remote` fields which relate to
+    # the DC/OS authentication token from the `dcos-acs-auth-cookie` cookie.
     jar['dcos-acs-info-cookie'] = (
         'eyJ1aWQiOiAiYm9vdHN0cmFwdXNlciIsICJkZX'
         'NjcmlwdGlvbiI6ICJCb290c3RyYXAgc3VwZXJ1c2VyIiwgImlzX3JlbW90ZSI6IGZ'
         'hbHNlfQ==')
 
     # First case - cookie contains ONLY dcos-specific cookies, `Cookie` header
-    # should not be send
+    # should not be sent
     generic_upstream_cookies_verify_test(
         ar_process,
         valid_user_header,

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -142,8 +142,8 @@ def _verify_is_upstream_req_ok_test_conf(t_config):
 
 
 def _verify_are_upstream_req_headers_ok(t_config):
-    assert 'jwt_should_be_forwarded' in t_config
-    assert t_config['jwt_should_be_forwarded'] in [True, False, 'skip']
+    assert 'auth_token_is_forwarded' in t_config
+    assert t_config['auth_token_is_forwarded'] in [True, False, 'skip']
 
     assert 'skip_authcookie_filtering_test' in t_config
     assert t_config['skip_authcookie_filtering_test'] in [True, False, 'skip']
@@ -229,7 +229,7 @@ def _testdata_to_are_upstream_req_headers_ok_testdata(tests_config, node_type):
 
         for p in h['test_paths']:
             e = (p,
-                 h['jwt_should_be_forwarded'],
+                 h['auth_token_is_forwarded'],
                  h['skip_authcookie_filtering_test'])
             res.append(e)
 

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
@@ -26,7 +26,8 @@ class TestAuthzIAMBackendQuery:
             )
 
         log_messages = {
-            'UID from valid JWT: `bozydar`': SearchCriteria(1, True),
+            'UID from the valid DC/OS authentication token: `bozydar`':
+                SearchCriteria(1, True),
             "Unexpected response from IAM: ":
                 SearchCriteria(1, True),
             }

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -26,7 +26,7 @@ endpoint_tests:
           - /acs/api/v1/auth/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /acs/api/v1/auth/reflect/me
       is_upstream_correct:
@@ -47,7 +47,7 @@ endpoint_tests:
           - /dcos-metadata/ui-config.json
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /dcos-metadata/ui-config.json
       is_upstream_correct:

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -89,7 +89,7 @@ class TestAuthnJWTValidator:
             "No auth token in request.": SearchCriteria(0, True),
             "Invalid token. Reason: invalid jwt string":
                 SearchCriteria(0, True),
-            "UID from valid JWT: `test`": SearchCriteria(1, True),
+            "UID from the valid DC/OS authentication token: `test`": SearchCriteria(1, True),
             }
 
         token = jwt_generator(uid='test')
@@ -103,7 +103,8 @@ class TestAuthnJWTValidator:
 
     def test_valid_auth_token(self, master_ar_process_perclass, valid_user_header):
         log_messages = {
-            "UID from valid JWT: `bozydar`": SearchCriteria(1, True),
+            "UID from the valid DC/OS authentication token: `bozydar`":
+                SearchCriteria(1, True),
             }
         assert_endpoint_response(
             master_ar_process_perclass,
@@ -120,8 +121,10 @@ class TestAuthnJWTValidator:
             jwt_generator,
             ):
         log_messages = {
-            "UID from valid JWT: `bozydar`": SearchCriteria(1, True),
-            "UID from valid JWT: `test`": SearchCriteria(0, True),
+            "UID from the valid DC/OS authentication token: `bozydar`":
+                SearchCriteria(1, True),
+            "UID from the valid DC/OS authentication token: `test`":
+                SearchCriteria(0, True),
             }
 
         token = jwt_generator(uid='test')

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -3,7 +3,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /exhibitor/foo/bar
       is_upstream_correct:
@@ -39,7 +39,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
       is_upstream_correct:
@@ -195,7 +195,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
           - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
@@ -230,7 +230,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: true
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/health/v1/foo/bar
     type:
@@ -238,7 +238,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/health/v1/foo/bar
     type:
@@ -263,7 +263,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/foo/bar?key=value&var=num
@@ -297,7 +297,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0/foo/bar?key=value&var=num
@@ -332,7 +332,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
           - /system/v1/leader/marathon/foo/bar?key=value&var=num
@@ -367,7 +367,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: true
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/logs/foo/bar
     type:
@@ -375,7 +375,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/logs/foo/bar
     type:
@@ -405,7 +405,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /cosmos/service/foo/bar
       is_upstream_correct:
@@ -427,7 +427,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /capabilities
       is_upstream_correct:
@@ -450,7 +450,7 @@ endpoint_tests:
           - /acs/api/v1/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /acs/api/v1/reflect/me
       is_upstream_correct:
@@ -469,7 +469,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /package/foo/bar
       is_upstream_correct:
@@ -490,7 +490,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /navstar/lashup/key
       is_upstream_correct:
@@ -509,7 +509,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /dcos-history-service/foo/bar
       is_upstream_correct:
@@ -528,7 +528,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: false
+        auth_token_is_forwarded: false
         test_paths:
           - /mesos_dns/v1/reflect/me
       is_upstream_correct:
@@ -551,7 +551,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /mesos/reflect/me
       is_upstream_correct:
@@ -587,7 +587,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /pkgpanda/foo/bar
       is_location_header_rewritten:
@@ -601,7 +601,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: true
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /pkgpanda/foo/bar
       is_location_header_rewritten:
@@ -644,7 +644,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: true
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/metrics/foo/bar
       is_upstream_correct:
@@ -657,7 +657,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/metrics/foo/bar
       is_upstream_correct:
@@ -675,7 +675,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /marathon/
           - /marathon/v2/reflect/me


### PR DESCRIPTION
## High Level Description

Please check the Jira issue for details.

The PR is a little bit noisy because replacing `JWT` with `DC/OS authentication token` resulted in in some of the paragraphs needing to be reflowed. This problem will be addressed at some later time with a separate PR which will introduce semantic line feeds.

**CI failures are expected, please ignore. This will be addressed when merging the intermediate branch (prozlach/ar-next) to master. Same goes for upstream bump - testing this change has been done manually in EE repo, proper integration tests will be done when AR-NEXT is going to be shipped.**
**

## Related Issues

 - https://jira.mesosphere.com/browse/DCOS_OSS-1572 `Admin Router: Replace JWT with `DC/OS authentication token` in AR docs`

## Related PRs:
EE DC/OS PR: https://github.com/mesosphere/dcos-enterprise/pull/1346
AR-Next PR: https://github.com/dcos/dcos/pull/1866