### PR TITLE
Admin Router: Configure /mesos endpoint for streaming API

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -240,6 +240,15 @@ location /mesos/ {
     access_by_lua_block {
         auth.access_mesos_endpoint();
     }
+
+    # Non-streaming endpoints don't require HTTP/1.1 but will work as
+    # expected with it enabled. Streaming endpoints require keepalive
+    # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
+    # while maintaining backwards compatibility.
+    include includes/http-11.conf;
+    # Disable buffering to support streaming Mesos v1 streaming API:
+    proxy_buffering off;
+
     include includes/proxy-headers.conf;
     rewrite ^/mesos/(.*) /$1 break;
     proxy_pass $upstream_mesos;

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -521,7 +521,7 @@ endpoint_tests:
           - /mesos/reflect/me
         upstream: http://127.0.0.2:5050
       is_upstream_req_ok:
-        expected_http_ver: HTTP/1.0
+        expected_http_ver: HTTP/1.1
         test_paths:
           - expected: /reflect/me
             sent: /mesos/reflect/me


### PR DESCRIPTION
## High Level Description

**This is https://github.com/dcos/dcos/pull/1847 but this time created against AR-NEXT CI failures are to be expected - I will make them green while `ShipIt`-ing AR-NEXT branches. Same goes for upstream bump - testing this change has been done manually in EE repo, proper integration tests will be done when AR-NEXT is going to be shipped.**
**

This PR disables upstream response buffering for `/mesos` endpoint in order to make it possible for UI to use Mesos Streaming API.

Very similar change has been already introduced to `/agent` endpoint in order to support task console redirection. I double-checked with #core and nobody objected:

https://mesosphere.slack.com/archives/C02CGA57K/p1503428565000424

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS_OSS-1487 Admin Router: configure for Mesos V1 Streaming API

## Related PRs

Open DC/OS AR-NEXT PR: https://github.com/dcos/dcos/pull/1866