### PR TITLE
Admin Router: Remove authz from /metadata endpoint

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -2,7 +2,7 @@
 # Description: List the active Pkgpanda packages
 location /pkgpanda/active.buildinfo.full.json {
     access_by_lua_block {
-        auth.access_metadata_endpoint();
+        auth.access_misc_metadata_endpoint();
     }
     include includes/disable-response_caching.conf;
     alias /opt/mesosphere/active.buildinfo.full.json;

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -74,7 +74,7 @@ location /cache/master/ {
 # Description: DC/OS metadata
 location /dcos-metadata/ {
     access_by_lua_block {
-        auth.access_metadata_endpoint();
+        auth.access_misc_metadata_endpoint();
     }
     alias /opt/mesosphere/active/dcos-metadata/etc/;
 }

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -108,9 +108,13 @@ function _M.init(use_auth)
         return res.do_authn_and_authz_or_exit()
     end
 
-    -- /metadata
     -- /pkgpanda/active.buildinfo.full.json
     -- /dcos-metadata/
+    res.access_misc_metadata_endpoint = function()
+        return res.do_authn_and_authz_or_exit()
+    end
+
+    -- /metadata
     res.access_metadata_endpoint = function()
         return res.do_authn_and_authz_or_exit()
     end


### PR DESCRIPTION
## High Level Description

**This is https://github.com/dcos/dcos/pull/1828 but this time created against AR-NEXT. CI failures are to be expected - I will make them green while `ShipIt`-ing AR-NEXT branches. Same goes for upstream bump - testing this change has been done manually in EE repo, proper integration tests will be done when AR-NEXT is going to be shipped.** 

This PR removes authz from `/metadata` endpoint. Please see linked Jira issues for the reasoning behind this PR and other details.

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-14563 Admin Router: switch /metadata to "allow all authenticated users" instead of ACL lookup

## Related PRs

DC/OS EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1299
Open DC/OS AR-NEXT PR: https://github.com/dcos/dcos/pull/1866