### PR TITLE
Admin Router: Bump OpenResty package to 1.11.2.4

### DIFF
--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
 # Let's try to limit the number of layers to minimum:
-ENV OPENRESTY_VERSION=1.9.15.1 \
-    OPENRESTY_DOWNLOAD_SHASUM=491a84d70ed10b79abb9d1a7496ee57a9244350b \
+ENV OPENRESTY_VERSION=1.11.2.4 \
+    OPENRESTY_DOWNLOAD_SHASUM=7449c57cf53e3ac963736b7e0333c929688b5bfc \
     OPENRESTY_DIR=/usr/local/src/openresty \
     OPENRESTY_COMPILE_SCRIPT=/usr/local/src/build-resty.sh \
     OPENRESTY_COMPILE_OPTS="" \
@@ -56,6 +56,7 @@ RUN set -ex \
         libpcre++-dev \
         libssl-dev \
         make \
+        patch \
         python3 \
         python3-dev \
         python3-pip \
@@ -93,12 +94,14 @@ RUN curl -fsSL "$VEGETA_DOWNLOAD_URL" -o vegeta.tar.gz \
 
 # Prepare Openresty. Compilation is done in Makefile itself so that
 # this container can be reused during DC/OS build.
+COPY openresty-1.11.2.4-no_sse42.patch /usr/local/src/
 RUN set -ex \
     && curl -fsSL "$OPENRESTY_DOWNLOAD_URL" -o openresty.tar.gz \
     && echo "$OPENRESTY_DOWNLOAD_SHASUM  openresty.tar.gz" | shasum -c - \
     && mkdir -pv $OPENRESTY_DIR \
     && tar --strip-components=1 -C $OPENRESTY_DIR -xzf openresty.tar.gz \
-    && rm openresty.tar.gz
+    && rm openresty.tar.gz \
+    && patch -p1 openresty/configure openresty-1.11.2.4-no_sse42.patch
 
 COPY build-resty.sh $OPENRESTY_COMPILE_SCRIPT
 

--- a/packages/adminrouter/docker/openresty-1.11.2.4-no_sse42.patch
+++ b/packages/adminrouter/docker/openresty-1.11.2.4-no_sse42.patch
@@ -1,0 +1,32 @@
+diff -Nwrup openresty-1.11.2.4.orig/configure openresty-1.11.2.4/configure
+--- openresty-1.11.2.4.orig/configure	2017-08-18 17:56:10.525812446 +0200
++++ openresty-1.11.2.4/configure	2017-08-18 17:57:36.720556459 +0200
+@@ -626,28 +626,6 @@ _END_
+             $luajit_xcflags .= " -DLUAJIT_ENABLE_LUA52COMPAT";
+         }
+ 
+-        {
+-            # check -msse4.2
+-            my ($out, $cfile) = tempfile("resty-config-XXXXXX",
+-                                         SUFFIX => '.c', TMPDIR => 1,
+-                                         UNLINK => 1);
+-
+-            print $out "int main(void) { return 0; }";
+-            close $out;
+-
+-            my $ofile = tmpnam();
+-            my $comp = ($cc || 'cc');
+-
+-            if (system("$comp -o $ofile -msse4.2 -c $cfile") == 0 && -s $ofile) {
+-                print "INFO: found -msse4.2 in $comp.\n";
+-                $luajit_xcflags .= " -msse4.2";
+-                unlink $ofile;
+-
+-            } else {
+-                print "WARNING: -msse4.2 not supported in $comp.\n";
+-            }
+-        }
+-
+         if ($opts->{debug}) {
+             $luajit_xcflags .= " -DLUA_USE_APICHECK -DLUA_USE_ASSERT";
+             $luajit_xcflags =~ s/^ +//;


### PR DESCRIPTION
## High Level Description

**CI failures are to be expected - I will make them green while `ShipIt`-ing AR-NEXT branches. Same goes for upstream bump - testing this change has been done manually in EE repo, proper integration tests will be done when AR-NEXT is going to be shipped.**

This PR updates OpenResty package used by AR to `1.11.2.4` from `1.9.15.1`. Unfortunatelly Openresty now enables `-sse4.2` LuaJIT flag by default if the build machine supports it. Some of our customers may still be running old machines that do not support it, hence the buildscripts patch Openresty in order to disable the `-sse4.2` flag heuristics permamently.

SHASUM of the openresty tarball has been verified with agenttz PGP key: https://pgp.mit.edu/pks/lookup?op=get&search=0xB550E09EA0E98066

## Changelogs:
### Links:
* OpenResty: http://openresty.org/en/changelog-1011002.html
* NGINX: http://nginx.org/en/CHANGES
### Things that may be relevant to us:
#### OpenResty:
* feature: now we automatically add the -msse4.2 compilation option for building the bundled LuaJIT when it is available.
* bugfix: fake connections did not carry a proper connection number. thanks Piotr Sikora for the patch.
* change: now we enable -DLUAJIT_ENABLE_LUA52COMPAT in our bundled LuaJIT build by default, which can be disabled by ./configure --without-luajit-lua52. note that this change may introduce some minor backeward incompatibilities on the Lua land, see http://luajit.org/extensions.html#lua52 for more details.
#### NGINX:
```
Changes with nginx 1.11.1                                        31 May 2016

    *) Security: a segmentation fault might occur in a worker process while
       writing a specially crafted request body to a temporary file
       (CVE-2016-4450); the bug had appeared in 1.3.9.
```    

## Related Issues

 - https://jira.mesosphere.com/browse/DCOS-9657 Admin Router: update to openresty/nginx 1.11.x

## Related PRs:

Open DC/OS AR-NEXT PR: https://github.com/dcos/dcos/pull/1866
Enterprise DC/OS PR: https://github.com/mesosphere/dcos-enterprise/pull/1319