### PR TITLE
Admin Router: Expose agent's `/dcos-metadata/dcos-version.json` through `/system/v1/agent/` endpoint

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -50,19 +50,20 @@ location ~ ^/system/v1/leader/marathon(?<url>.*)$ {
 
 # Group: System
 # Description: System proxy to a specific agent node
-location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0))(?<url>.*)$ {
+location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)$ {
     set $agentaddr '';
     rewrite_by_lua_block {
         auth.access_system_agent_endpoint();
         agent.resolve();
         util.clear_dcos_cookies();
     }
-    rewrite ^/agent/[0-9a-zA-Z-]+(.*)$ $1 break;
+    rewrite ^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*) /system/v1$url break;
+    rewrite ^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json /dcos-metadata/dcos-version.json break;
 
     more_clear_input_headers Accept-Encoding;
     include includes/http-11.conf;
     include includes/proxy-headers.conf;
-    proxy_pass $agentaddr:$adminrouter_agent_port/system/v1$type$url$is_args$query_string;
+    proxy_pass $agentaddr:$adminrouter_agent_port;
 }
 
 # Group: Mesos DNS

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -291,6 +291,8 @@ endpoint_tests:
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs
           - expected: /system/v1/metrics/v0
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0
+          - expected: /dcos-metadata/dcos-version.json
+            sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/dcos-metadata/dcos-version.json
     type:
       - master
 # Agent B
@@ -325,6 +327,8 @@ endpoint_tests:
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs
           - expected: /system/v1/metrics/v0
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0
+          - expected: /dcos-metadata/dcos-version.json
+            sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/dcos-metadata/dcos-version.json
     type:
       - master
 


### PR DESCRIPTION
## High Level Description

**CI failures are expected, please ignore. This will be addressed when merging the intermediate branch (prozlach/ar-next) to master. Same goes for upstream bump - testing this change has been done manually in EE repo, proper integration tests will be done when AR-NEXT is going to be shipped.**

Please check the Jira issue for details regarding this change.

## Related Issues
 - https://jira.mesosphere.com/browse/DCOS-13534 `Expose DC/OS Agent version info from the 'dcos-metadata/dcos-version.json' endpoint`

## Related PRs:
AR-Next PR: https://github.com/dcos/dcos/pull/1866