### PR TITLE
Admin Router: Routing of `/service/(marathon|metronome)` endpoint should use only Mesos data

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -390,6 +390,14 @@ necessary - from MesosDNS:
   In the case where MesosDNS returns no results, AR assumes that there is no
   task nor framework with the given application ID running on DC/OS.
 
+A bit of a special case is `/service/marathon` and `/service/metronome`. They
+will never be present in Root Marathon's taks list hence we skip the first step
+of the iteration. The reason for that is the fact that these frameworks are
+launched on Master nodes using systemd. This improves the reliability a bit as
+the failure of the local Root Marathon/Root Metronome does not prevent
+`/service` entpoint to route to the healthy leader running on some other hosts
+(provided that there is a leader).
+
 #### Stale cache/broken cache cases
 The `/service` endpoint internally uses the AR cache, so a failure to refresh
 the cache has the same effects on the `/service` endpoint like any other

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
@@ -125,6 +125,8 @@ class MockerBase:
             ReflectingTcpIpEndpoint(ip='127.0.0.1', port=1050))
         res.append(
             ReflectingUnixSocketEndpoint('/run/dcos/dcos-diagnostics.sock'))
+        # DC/OS Metronome
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.1', port=9000))
         # TODO - other endpoints common for all flavours go here...
 
         return res

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
@@ -70,6 +70,7 @@ def framework_from_template(fid, name, webui_url):
     return res
 
 SCHEDULER_FWRK_MARATHON_ID = '819aed93-4143-4291-8ced-5afb5c726803-0000'  # noqa: E305
+SCHEDULER_FWRK_METRONOME_ID = '777aed93-4143-4291-8ced-5afb5c726803-0000'  # noqa: E305
 SCHEDULER_FWRK_ALWAYSTHERE_ID = '0f8899bf-a31a-44d5-b1a5-c8c3f7128905-0000'  # noqa: E305
 SCHEDULER_FWRK_ALWAYSTHERE_NEST1_ID = '4bfed1de-5c6c-48fa-931c-9f0468387db5-0000'  # noqa: E305
 SCHEDULER_FWRK_ALWAYSTHERE_NEST2_ID = '08cc2799-9380-469f-82ca-e4527ced3d8b-0000'  # noqa: E305
@@ -81,6 +82,10 @@ SCHEDULER_FWRK_MARATHON = framework_from_template(
     SCHEDULER_FWRK_MARATHON_ID,
     "marathon",
     "http://127.0.0.1:8080")
+SCHEDULER_FWRK_METRONOME = framework_from_template(
+    SCHEDULER_FWRK_METRONOME_ID,
+    "metronome",
+    "http://127.0.0.1:9000")
 SCHEDULER_FWRK_ALWAYSTHERE = framework_from_template(
     SCHEDULER_FWRK_ALWAYSTHERE_ID,
     "scheduler-alwaysthere",
@@ -205,6 +210,7 @@ EXTRA_AGENT_DICT = agent_from_template(
 INITIAL_STATEJSON = {
     "cluster": "prozlach-qzpz04t",
     "frameworks": [SCHEDULER_FWRK_MARATHON,
+                   SCHEDULER_FWRK_METRONOME,
                    SCHEDULER_FWRK_ALWAYSTHERE,
                    SCHEDULER_FWRK_ALWAYSTHERE_NEST1,
                    SCHEDULER_FWRK_ALWAYSTHERE_NEST2,

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -701,3 +701,26 @@ endpoint_tests:
             code: 307
     type:
       - master
+######### This is a special case of a service behind /service endpoint:
+######### /service/metronome
+  - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        auth_token_is_forwarded: true
+        test_paths:
+          - /service/metronome/
+          - /service/metronome/v2/reflect/me
+      is_upstream_correct:
+        test_paths:
+          - /service/metronome/
+          - /service/metronome/v2/reflect/me
+        upstream: http://127.0.0.1:9000
+      is_upstream_req_ok:
+        expected_http_ver: websockets
+        test_paths:
+          - expected: /v2/reflect/me
+            sent: /service/metronome/v2/reflect/me
+          - expected: /
+            sent: /service/metronome/
+    type:
+      - master

--- a/packages/adminrouter/extra/src/test-harness/tests/test_service.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_service.py
@@ -683,6 +683,73 @@ class TestServiceStateful:
         assert resp.status_code == 503
         assert '503 Service Unavailable: invalid Marathon svcapps cache' in resp.text
 
+    def test_if_broken_marathon_does_not_prevent_resolving_root_marathon(
+            self, mocker, nginx_class, valid_user_header):
+        # Bork Marathon Mock, DO NOT touch Mesos Mock:
+        mocker.send_command(
+            endpoint_id='http://127.0.0.1:8080',
+            func_name='always_bork',
+            aux_data=True)
+        # Change the Root Marathon's endpoint address as reported by Mesos mock,
+        # so that we do not get the reply from the original endpoint (i.e.
+        # http://127.0.0.1:8080 as it will always respond with broken responses
+        # (see `mocker.send_command` call above).
+        fwrk = framework_from_template(
+            SCHEDULER_FWRK_ALWAYSTHERE_ID,
+            "marathon",
+            "http://127.0.0.2:8080/")
+        mocker.send_command(endpoint_id='http://127.0.0.2:5050',
+                            func_name='set_frameworks_response',
+                            aux_data=[fwrk])
+
+        # Make period cache refreshes so rare that they do not get into
+        # picture:
+        ar = nginx_class(cache_first_poll_delay=1200,
+                         cache_poll_period=1200,
+                         cache_expiration=1200,
+                         cache_max_age_soft_limit=1200,
+                         cache_max_age_hard_limit=1800,
+                         )
+        url = ar.make_url_from_path("/service/marathon/v2/reflect/me")
+
+        with GuardedSubprocess(ar):
+            resp = requests.get(
+                url,
+                allow_redirects=False,
+                headers=valid_user_header)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['endpoint_id'] == 'http://127.0.0.2:8080'
+
+    def test_if_broken_marathon_does_not_prevent_resolving_root_metronome(
+            self, mocker, nginx_class, valid_user_header):
+        # Bork Marathon Mock, DO NOT touch Mesos Mock:
+        mocker.send_command(
+            endpoint_id='http://127.0.0.1:8080',
+            func_name='always_bork',
+            aux_data=True)
+
+        # Make period cache refreshes so rare that they do not get into
+        # picture:
+        ar = nginx_class(cache_first_poll_delay=1200,
+                         cache_poll_period=1200,
+                         cache_expiration=1200,
+                         cache_max_age_soft_limit=1200,
+                         cache_max_age_hard_limit=1800,
+                         )
+        url = ar.make_url_from_path("/service/metronome/foo/bar")
+
+        with GuardedSubprocess(ar):
+            resp = requests.get(
+                url,
+                allow_redirects=False,
+                headers=valid_user_header)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['endpoint_id'] == 'http://127.0.0.1:9000'
+
     def test_if_broken_mesos_prevents_resolving_via_mesosdns(
             self, mocker, nginx_class, valid_user_header):
         # Bork Mesos Mock, Make Marathon mock respond with no apps, so that AR


### PR DESCRIPTION
## High Level Description

**CI failures are expected, please ignore. This will be addressed when merging the intermediate branch (prozlach/ar-next) to master. Same goes for upstream bump - I have done EE tests manually using AR tests, proper integration tests will be done while shipping AR-NEXT branches.**

Please check Jira issue for details

## Related Issues

 - https://jira.mesosphere.com/browse/DCOS_OSS-1227 `Admin Router: Make /service endpoint logic go directly to Mesos /state-summary data for Root Marathon and Metronome`

## Related PRs

Open DC/OS AR-Next PR: https://github.com/dcos/dcos/pull/1866
