### PR TITLE
Bump used sec-ci-libs to v2, adjust Jenkinsfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('sec_ci_libs') _
+@Library('sec_ci_libs@v2-latest') _
 
 def master_branches = ["master", ] as String[]
 
@@ -11,9 +11,9 @@ if (master_branches.contains(env.BRANCH_NAME)) {
     ])
 }
 
-task_wrapper('mesos-sec', master_branches){
+task_wrapper('mesos-sec', master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-security-ci') {
     stage("Verify author") {
-        user_is_authorized(master_branches)
+        user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-security-ci')
     }
 
     stage('Cleanup workspace') {


### PR DESCRIPTION
## High Level Description

This PR adjust project's Jenkinsfiles in order to support the new way in which `sec-ci-lib` is called.

In order to enable other teams to reuse `sec-ci-lib`, both slack channel and slack token ID must be passed as parameter. This also requires a new approach on versioning `sec-ci-lib` libs - see the discussion in https://github.com/mesosphere/sec-ci-libs/pull/5 for more details.

## Related PRs
PR that introduces the changehttps://github.com/mesosphere/sec-ci-libs/pull/5
AR-NEXT #5 PR: <TBD>
DC/OS EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1408