### PR TITLE
Add Fluent Bit service accounts

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -122,6 +122,8 @@ bootstrappers = {
     'dcos-diagnostics-agent': noop,
     'dcos-checks-master': noop,
     'dcos-checks-agent': noop,
+    'dcos-fluent-bit-master': noop,
+    'dcos-fluent-bit-agent': noop,
     'dcos-marathon': noop,
     'dcos-mesos-master': noop,
     'dcos-mesos-slave': noop,

--- a/packages/fluent-bit/build
+++ b/packages/fluent-bit/build
@@ -14,6 +14,20 @@ popd
 # Remove Fluent Bit's default config.
 rm -rf "$PKG_PATH/etc"
 
-# Add systemd unit file.
-mkdir -p "$PKG_PATH/dcos.target.wants/"
-cp /pkg/extra/dcos-fluent-bit.service "$PKG_PATH/dcos.target.wants/"
+# Add systemd unit files.
+# We use different unit files per role because Fluent Bit uses one service account on masters and another on agents.
+unit_template="/pkg/extra/dcos-fluent-bit.service"
+master_unit="$PKG_PATH/dcos.target.wants_master/dcos-fluent-bit.service"
+agent_unit="$PKG_PATH/dcos.target.wants_slave/dcos-fluent-bit.service"
+agent_public_unit="$PKG_PATH/dcos.target.wants_slave_public/dcos-fluent-bit.service"
+
+# Add the master unit file to the package.
+mkdir -p $(dirname "$master_unit")
+SERVICE="dcos-fluent-bit-master" envsubst '${SERVICE} ${PKG_PATH}' < "$unit_template" > "$master_unit"
+
+# Add the agent unit files to the package.
+# Agents and public agents have the same unit file contents.
+for unit in "$agent_unit" "$agent_public_unit"; do
+  mkdir -p $(dirname "$unit")
+  SERVICE="dcos-fluent-bit-agent" envsubst '${SERVICE} ${PKG_PATH}' < "$unit_template" > "$unit"
+done

--- a/packages/fluent-bit/extra/dcos-fluent-bit.service
+++ b/packages/fluent-bit/extra/dcos-fluent-bit.service
@@ -14,4 +14,5 @@ EnvironmentFile=/opt/mesosphere/etc/fluent-bit.env
 
 LimitNOFILE=16384
 
+ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/fluent-bit --config ${FLUENT_BIT_CONFIG_FILE}


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-44454

This adds service accounts for Fluent Bit to https://github.com/dcos/dcos/pull/4777, one for masters and another for agents.

DC/OS PR: https://github.com/dcos/dcos/pull/4811

TODO: 

- [ ] Resolve merge conflicts after #64 is merged.